### PR TITLE
make admin password configurable in Helm Chart

### DIFF
--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -37,9 +37,15 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
-          args:  [ '--tunnel-port','{{ .Values.service.edgeNodePort }}' ]
-      {{- end }}          
+          args:
+          {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
+            - '--tunnel-port'
+            - '{{ .Values.service.edgeNodePort }}'
+          {{- end }}          
+          {{- if (not (empty .Values.admin.password)) }}
+            - '--admin-password'
+            - '{{ .Values.admin.password }}'
+          {{- end }}          
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+admin:
+  user: admin
+  password:
+
 # If enterpriseEdition is enabled, then use the values below _instead_ of those in .image
 enterpriseEdition: 
   enabled: false


### PR DESCRIPTION
Hi,

picking up on a [discussion](https://portainerinternal.slack.com/archives/G01FDN68HQF/p1628683473001900) in the Ambassador Slack. My team is working on a Kubernetes Platform and tries to integrate Portainer as an application. For this we'd need to be able to bootstrap Portainer with a password (and ideally even more config revolving around auth and endpoints).

This MR deals with the necessary changes to accept a config value `admin.password` (a HASH built according to [your docs](https://documentation.portainer.io/v2.0/deploy/initial/)) that results in the `--admin-password` flag being added to the `args` section of the container spec if not empty.

This is a typical use case for us (and has been in the years before with Docker Swarm) so we thought to submit a PR for discussion instead of hacking a way around it or forking the chart.