### PR TITLE
Add optional password secret

### DIFF
--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -39,12 +39,12 @@ spec:
           {{- end }}
           args:
           {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
-            - '--tunnel-port'
-            - '{{ .Values.service.edgeNodePort }}'
+            - "--tunnel-port"
+            - "{{ .Values.service.edgeNodePort }}"
           {{- end }}          
           {{- if (not (empty .Values.admin.password)) }}
-            - '--admin-password'
-            - '{{ .Values.admin.password }}'
+            - "--admin-password"
+            - "'${ADMIN_PASSWORD_HASH}'"
           {{- end }}          
           volumeMounts:
             - name: data
@@ -66,3 +66,11 @@ spec:
               port: 9000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- if (not (empty .Values.admin.password)) }}
+            - name: ADMIN_PASSWORD_HASH
+              valueFrom:
+                secretKeyRef:
+                  name: portainer-initial-credentials
+                  key: password
+            {{- end }}

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -37,9 +37,15 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
-          args:  [ '--tunnel-port','{{ .Values.service.edgeNodePort }}' ]
-      {{- end }}          
+          args:
+          {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
+            - '--tunnel-port'
+            - '{{ .Values.service.edgeNodePort }}'
+          {{- end }}          
+          {{- if (not (empty .Values.admin.password)) }}
+            - '--admin-password'
+            - '{{ .Values.admin.password }}'
+          {{- end }}          
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/portainer/templates/secret.yml
+++ b/charts/portainer/templates/secret.yml
@@ -1,0 +1,13 @@
+{{ $htpasswdString := htpasswd .Values.admin.username .Values.admin.password -}}
+{{ $htpasswdHash := split ":" $htpasswdString -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: portainer-initial-credentials
+  namespace: {{ .Release.Namespace }}  
+  labels:
+    {{- include "portainer.selectorLabels" . | nindent 8 }}
+data:
+  username: {{ default "" .Values.admin.username | b64enc | quote }}
+  password: {{ $htpasswdHash._1 | b64enc | quote }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 admin:
-  user: admin
-  password:
+  username: admin
+  password: 
 
 # If enterpriseEdition is enabled, then use the values below _instead_ of those in .image
 enterpriseEdition: 

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+admin:
+  user: admin
+  password:
+
 # If enterpriseEdition is enabled, then use the values below _instead_ of those in .image
 enterpriseEdition: 
   enabled: false


### PR DESCRIPTION
Reworked the solution as suggested in [PR71](https://github.com/portainer/k8s/pull/71).

Still WIP. With the current implementation (using HELM's built-in `htpasswd` function), login with configured credentials is not possible. I suspend this to be a result of HELM's htpasswd not using bycrypt.