### PR TITLE
feat(helm): introduce TLS only flag

### DIFF
--- a/.github/workflows/on-push-lint-charts.yml
+++ b/.github/workflows/on-push-lint-charts.yml
@@ -4,7 +4,10 @@ on:
   push:
     paths:
       - 'charts/**' 
-      - '.github/**'            
+      - '.github/**'
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 env:

--- a/charts/portainer/Chart.yaml
+++ b/charts/portainer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.19
+version: 1.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/portainer/README.md
+++ b/charts/portainer/README.md
@@ -77,6 +77,8 @@ The following table lists the configurable parameters of the Portainer chart and
 | `ingress.hosts.paths.port` | Port for the Portainer Web. | `9000` |
 | `ingress.tls` | TLS support on ingress. Must create a secret with TLS certificates in advance | `[]` |
 | `resources` | Portainer resource requests and limits | `{}` |
+| `tls.force` | Force Portainer to be configured to use TLS only | `false` |
+| `tls.existingSecret` | Mount the existing TLS secret into the pod | `""` |
 | `persistence.enabled` | Whether to enable data persistence | `true` |
 | `persistence.existingClaim` | Name of an existing PVC to use for data persistence | `nil` |
 | `persistence.size` | Size of the PVC used for persistence | `10Gi` |
@@ -84,5 +86,3 @@ The following table lists the configurable parameters of the Portainer chart and
 | `persistence.storageClass` | StorageClass to apply to PVC used for persistence | `default` |
 | `persistence.accessMode` | AccessMode for persistence | `ReadWriteOnce` |
 | `persistence.selector` | Selector for persistence | `nil` |
-
-

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -43,13 +43,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- end }}
           args: 
-      {{- if .Values.tls.existingSecret }}
+          {{- if .Values.tls.force }}
+          - --http-disabled
+          {{- end }}
+          {{- if .Values.tls.existingSecret }}
           - --sslcert=/certs/tls.crt
           - --sslkey=/certs/tls.key
-      {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
+          {{- end }}
+          {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
           - '--tunnel-port={{ .Values.service.edgeNodePort }}'
-      {{- end }}          
+          {{- end }}          
           volumeMounts:
             - name: data
               mountPath: /data
@@ -57,26 +60,38 @@ spec:
             - name: certs
               mountPath: /certs
               readOnly: true
-            {{- end }}              
+            {{- end }}
           ports:
+            {{- if not .Values.tls.force }}
             - name: http
               containerPort: 9000
               protocol: TCP
+            {{- end }}
             - name: https
               containerPort: 9443
-              protocol: TCP                
+              protocol: TCP
             - name: tcp-edge
               containerPort: 8000
-              protocol: TCP              
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
+              {{- if .Values.tls.force }}
               port: 9443
               scheme: HTTPS
+              {{- else }}
+              port: 9000
+              scheme: HTTP
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /
+              {{- if .Values.tls.force }}
               port: 9443
-              scheme: HTTPS        
+              scheme: HTTPS
+              {{- else }}
+              port: 9000
+              scheme: HTTP
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/portainer/templates/service.yaml
+++ b/charts/portainer/templates/service.yaml
@@ -15,13 +15,15 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if not .Values.tls.force }}
     - port: {{ .Values.service.httpPort }}
       targetPort: 9000
       protocol: TCP
       name: http
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.httpNodePort))) }}
       nodePort: {{ .Values.service.httpNodePort}}
-      {{- end }}  
+      {{- end }}
+    {{- end }}
     - port: {{ .Values.service.httpsPort }}
       targetPort: 9443
       protocol: TCP
@@ -29,7 +31,7 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.httpsNodePort))) }}
       nodePort: {{ .Values.service.httpsNodePort}}
       {{- end }}
-    {{- if (eq .Values.service.type "NodePort") }}      
+    {{- if (eq .Values.service.type "NodePort") }}
     - port: {{ .Values.service.edgeNodePort }}
       targetPort: {{ .Values.service.edgeNodePort }}
       {{- else }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -39,6 +39,8 @@ service:
   annotations: {}
 
 tls:
+  # If set, Portainer will be configured to use TLS only
+  force: false
   # If set, will mount the existing secret into the pod
   existingSecret: ""
 


### PR DESCRIPTION
This PR is to introduce a flag called `tls.force` (`false` by default) to enforce HTTPS on:
- Kubernetes service - `9443` only, removing `9000`
- Kubernetes pod `containerPort` - `9443` only, removing `9000`
- Kubernetes pod `livenessProbe` and `readinessProbe` - `9443`, instead of `9000`
- Portainer - `--http-disabled` flag

Also, at present, as the `livenessProbe` and `readinessProbe` is `9443` by default, end users who use the latest Helm chart with older version of Portainer image with no HTTPS support won't work. This PR will remediate that issue.

