### PR TITLE
Introduce Portainer Feature Flag

### DIFF
--- a/charts/portainer/Chart.yaml
+++ b/charts/portainer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.20
+version: 1.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/portainer/README.md
+++ b/charts/portainer/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Portainer chart and
 | `service.edgePort` | TCP port for accessing Portainer Edge | `8000` |
 | `service.edgeNodePort` | Static NodePort for accessing Portainer Edge. Specify only if the type is NodePort | `30776` |
 | `service.annotations` | Annotations to add to the service | `{}` |
+| `feature.flags` | Enable one or more features separated by spaces. For instance, `--feat=open-amt` | `nil` |
 | `ingress.enabled` | Create an ingress for Portainer | `false` |
 | `ingress.annotations` | Annotations to add to the ingress. For instane, `kubernetes.io/ingress.class: nginx` | `{}` |
 | `ingress.hosts.host` | URL for Portainer Web. For instance, `portainer.example.io` | `nil` |

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -18,17 +18,17 @@ spec:
       labels:
         {{- include "portainer.selectorLabels" . | nindent 8 }}
     spec:
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 -}}      
-    {{- with .Values.imagePullSecrets }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "portainer.serviceAccountName" . }}
       volumes:
         - name: "data"
           persistentVolumeClaim:
             claimName: {{ template "portainer.pvcName" . }}
-      {{- if .Values.tls.existingSecret }}
+        {{- if .Values.tls.existingSecret }}
         - name: certs
           secret:
             secretName: {{ .Values.tls.existingSecret }}
@@ -52,7 +52,10 @@ spec:
           {{- end }}
           {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.edgeNodePort))) }}
           - '--tunnel-port={{ .Values.service.edgeNodePort }}'
-          {{- end }}          
+          {{- end }}
+          {{- if (not (empty .Values.feature.flags)) }}
+          - '{{ .Values.feature.flags }}'
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/portainer/templates/pvc.yaml
+++ b/charts/portainer/templates/pvc.yaml
@@ -4,7 +4,7 @@ kind: "PersistentVolumeClaim"
 apiVersion: "v1"
 metadata:
   name: {{ template "portainer.fullname" . }}
-  namespace: {{ .Release.Namespace }}  
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
@@ -16,7 +16,7 @@ metadata:
   {{ end }}
   labels:
     io.portainer.kubernetes.application.stack: portainer
-    {{- include "portainer.labels" . | nindent 4 }}  
+    {{- include "portainer.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ default "ReadWriteOnce" .Values.persistence.accessMode | quote }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -44,6 +44,9 @@ tls:
   # If set, will mount the existing secret into the pod
   existingSecret: ""
 
+feature:
+  flags: ""
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
This PR is to introduce a flag called `feature.flags` (`""` by default) to support enabling Portainer features parsed as an argument:
```sh
containers:
......
	args: 
......		
	{{- if (not (empty .Values.feature.flags)) }}
		- '{{ .Values.feature.flags }}'
	{{- end }}
```

An example is `--feat=open-amt`.