### PR TITLE
fix(k8s/helm): change to https only causing service crash with helm install

### DIFF
--- a/charts/portainer/Chart.yaml
+++ b/charts/portainer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.23
+version: 1.0.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -83,8 +83,13 @@ spec:
               port: 9443
               scheme: HTTPS
               {{- else }}
+                {{- if .Values.service.httpsPort }}
+              port: 9443
+              scheme: HTTPS
+                {{- else }}
               port: 9000
               scheme: HTTP
+                {{- end }}
               {{- end }}
           readinessProbe:
             httpGet:
@@ -93,8 +98,13 @@ spec:
               port: 9443
               scheme: HTTPS
               {{- else }}
+                {{- if .Values.service.httpsPort }}
+              port: 9443
+              scheme: HTTPS
+                {{- else }}
               port: 9000
               scheme: HTTP
+                {{- end }}
               {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -83,12 +83,25 @@ spec:
               port: 9443
               scheme: HTTPS
               {{- else }}
-                {{- if .Values.service.httpsPort }}
+                {{- if .Values.enterpriseEdition.enabled }}
+                  {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                {{- else }}
+                  {{- else }}
               port: 9000
               scheme: HTTP
+                  {{- end}}
+                {{- else }}
+                  {{- if eq .Values.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                  {{- else if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
+              port: 9443
+              scheme: HTTPS
+                  {{- else }}
+              port: 9000
+              scheme: HTTP
+                  {{- end }}
                 {{- end }}
               {{- end }}
           readinessProbe:
@@ -98,12 +111,25 @@ spec:
               port: 9443
               scheme: HTTPS
               {{- else }}
-                {{- if .Values.service.httpsPort }}
+                {{- if .Values.enterpriseEdition.enabled }}
+                  {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                {{- else }}
+                  {{- else }}
               port: 9000
               scheme: HTTP
+                  {{- end }}
+                {{- else }}
+                  {{- if eq .Values.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                  {{- else if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
+              port: 9443
+              scheme: HTTPS
+                  {{- else }}
+              port: 9000
+              scheme: HTTP
+                  {{- end }}
                 {{- end }}
               {{- end }}
           resources:


### PR DESCRIPTION
closes [EE-2502]

This PR allows the livenessProbe and readinessProbe port to be changed based on the image version and image tag version. 
Portainer introduced the ssl feature in CE 2.9.0 and BE 2.10.0, so we can say the image tag that is greater than CE 2.6.0 and BE 2.7.0 including `latest` will be used port 9443 by default. Otherwise, use 9000 


[EE-2502]: https://portainer.atlassian.net/browse/EE-2502?