### PR TITLE
fix(k8s/helm): add semantic version string check

### DIFF
--- a/charts/portainer/Chart.yaml
+++ b/charts/portainer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.25
+version: 1.0.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -84,12 +84,22 @@ spec:
               scheme: HTTPS
               {{- else }}
                 {{- if .Values.enterpriseEdition.enabled }}
-                  {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
+                  {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.enterpriseEdition.image.tag }}
+                    {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                  {{- else }}
+                    {{- else }}
               port: 9000
               scheme: HTTP
+                    {{- end }}
+                  {{- else }}
+                    {{- if eq .Values.enterpriseEdition.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                    {{- else }}
+              port: 9000
+              scheme: HTTP
+                    {{- end }}
                   {{- end}}
                 {{- else }}
                   {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.image.tag }}
@@ -119,13 +129,23 @@ spec:
               scheme: HTTPS
               {{- else }}
                 {{- if .Values.enterpriseEdition.enabled }}
-                  {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
+                  {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.enterpriseEdition.image.tag }}
+                    {{- if eq (semver .Values.enterpriseEdition.image.tag | (semver "2.7.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                  {{- else }}
+                    {{- else }}
               port: 9000
               scheme: HTTP
-                  {{- end }}
+                    {{- end }}
+                  {{- else }}
+                    {{- if eq .Values.enterpriseEdition.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                    {{- else }}
+              port: 9000
+              scheme: HTTP
+                    {{- end }}
+                  {{- end}}
                 {{- else }}
                   {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.image.tag }}
                     {{- if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}

--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -92,15 +92,22 @@ spec:
               scheme: HTTP
                   {{- end}}
                 {{- else }}
-                  {{- if eq .Values.image.tag "latest" }}
+                  {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.image.tag }}
+                    {{- if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                  {{- else if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
-              port: 9443
-              scheme: HTTPS
-                  {{- else }}
+                    {{- else }}
               port: 9000
               scheme: HTTP
+                    {{- end}}
+                  {{- else }}
+                    {{- if eq .Values.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                    {{- else }}
+              port: 9000
+              scheme: HTTP
+                    {{- end }}
                   {{- end }}
                 {{- end }}
               {{- end }}
@@ -120,15 +127,22 @@ spec:
               scheme: HTTP
                   {{- end }}
                 {{- else }}
-                  {{- if eq .Values.image.tag "latest" }}
+                  {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.image.tag }}
+                    {{- if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
               port: 9443
               scheme: HTTPS
-                  {{- else if eq (semver .Values.image.tag | (semver "2.6.0").Compare) -1 }}
-              port: 9443
-              scheme: HTTPS
-                  {{- else }}
+                    {{- else }}
               port: 9000
               scheme: HTTP
+                    {{- end}}
+                  {{- else }}
+                    {{- if eq .Values.image.tag "latest" }}
+              port: 9443
+              scheme: HTTPS
+                    {{- else }}
+              port: 9000
+              scheme: HTTP
+                    {{- end }}
                   {{- end }}
                 {{- end }}
               {{- end }}


### PR DESCRIPTION
closes [EE-2502]

This PR will fix the below error while installing Portainer with helm chart image tag neither `latest` or `xx.xx.xx` format, such as `develop` and other specific branch name on internal infrastructure.  

>Error: template: portainer/templates/deployment.yaml:98:34: executing "portainer/templates/deployment.yaml" at <semver .Values.image.tag>: error calling semver: Invalid Semantic Version

Test cases for CE:
```
helm template portainer/ --set image.tag="develop"
helm template portainer/ --set image.tag="2.6.0"
helm template portainer/ --set image.tag="2.11.0"
helm template portainer/ --set image.tag="latest"
```

Test cases for EE:
```
helm template portainer/ --set enterpriseEdition.enabled=true --set enterpriseEdition.image.tag="2.7.0"
helm template portainer/ --set enterpriseEdition.enabled=true --set enterpriseEdition.image.tag="2.9.0"
helm template portainer/ --set enterpriseEdition.enabled=true --set enterpriseEdition.image.tag="develop"
helm template portainer/ --set enterpriseEdition.enabled=true --set enterpriseEdition.image.tag="latest"
```

[EE-2502]: https://portainer.atlassian.net/browse/EE-2502?