### PR TITLE
remove deprecated ways of specifying storage class

### DIFF
--- a/charts/portainer/templates/pvc.yaml
+++ b/charts/portainer/templates/pvc.yaml
@@ -7,11 +7,6 @@ metadata:
   name: {{ template "portainer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: "generic"
-  {{- end }}
   {{- if .Values.persistence.annotations }}
   {{ toYaml .Values.persistence.annotations | indent 2 }}  
   {{ end }}
@@ -24,6 +19,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  storageClassName: {{ if .Values.persistence.storageClass -}} {{ .Values.persistence.storageClass | quote }} {{- else -}} "" {{- end }}
   {{- if .Values.persistence.selector }}
   selector:
 {{ toYaml .Values.persistence.selector | indent 4 }}


### PR DESCRIPTION
Refs:

`volume.beta.kubernetes.io/storage-class` deprecated: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
```
A PV can have a class, which is specified by setting the storageClassName attribute to the name of a [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/). A PV of a particular class can only be bound to PVCs requesting that class. A PV with no storageClassName has no class and can only be bound to PVCs that request no particular class.

In the past, the annotation volume.beta.kubernetes.io/storage-class was used instead of the storageClassName attribute. This annotation is still working; however, it will become fully deprecated in a future Kubernetes release
```

`volume.alpha.kubernetes.io/storage-class` deprecated: https://github.com/kubernetes/kubernetes/issues/32225#issuecomment-248740936