### PR TITLE
Add code for allowing pod scheduling via affinity

### DIFF
--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- include "portainer.selectorLabels" . | nindent 8 }}
     spec:
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 -}}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -21,6 +21,8 @@ imagePullSecrets: []
 
 nodeSelector: {}
 
+affinity: {}
+
 serviceAccount:
   annotations: {}
   name: portainer-sa-clusteradmin


### PR DESCRIPTION
This minor update allows for users to use 'affinity:' instead of 'nodeSelector:' tags. Affinity has more scheduling options than nodeSelector.