### PR TITLE
Allow set volumeName to pvc

### DIFF
--- a/charts/portainer/templates/pvc.yaml
+++ b/charts/portainer/templates/pvc.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
   {{ end }}
+  {{- if .Values.persistence.volumeName }}
+  volumeName: {{ .Values.persistence.volumeName | quote }}
+  {{- end }}
   {{- if .Values.persistence.selector }}
   selector:
 {{ toYaml .Values.persistence.selector | indent 4 }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -74,4 +74,5 @@ persistence:
   size: "10Gi"
   annotations: {}
   storageClass:
+  # volumeName: ""
   existingClaim:


### PR DESCRIPTION
This patch allow set the volumeName parameter to pvc, this we can bound pvc to a fixed/existing pv.