### PR TITLE
Drop 1.19 Kube version support and lower

### DIFF
--- a/charts/portainer/templates/_helpers.tpl
+++ b/charts/portainer/templates/_helpers.tpl
@@ -72,16 +72,3 @@ Provide a pre-defined claim or a claim based on the Release
 {{- template "portainer.fullname" . }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Generate a right Ingress apiVersion
-*/}}
-{{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
-networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-networking.k8s.io/v1beta1
-{{- else -}}
-extensions/v1
-{{- end }}
-{{- end -}}

--- a/charts/portainer/templates/ingress.yaml
+++ b/charts/portainer/templates/ingress.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "portainer.fullname" . -}}
 {{- $tlsforced := .Values.tls.force -}}
-{{- $apiVersion := include "ingress.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -34,11 +33,8 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ .path | default "/" }}
-            {{- if eq $apiVersion "networking.k8s.io/v1" }}
             pathType: Prefix
-            {{- end }}
             backend:
-            {{- if eq $apiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}
                 port:
@@ -47,14 +43,6 @@ spec:
                 {{- else }}
                   number: {{ .port | default 9000 }}
                 {{- end }}
-            {{- else }}
-              serviceName: {{ $fullName }}
-              {{- if $tlsforced }}
-              servicePort: {{ .port | default 9443 }}
-              {{- else }}
-              servicePort: {{ .port | default 9000 }}
-              {{- end }}
-            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
I encountered an error creating an ingress with this chart saying `no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"`. This appears to be an issue with this [snippet](https://github.com/portainer/k8s/blob/c93529516027cb309cadb7df03562bb2657f53cc/charts/portainer/templates/_helpers.tpl#L76-L86) checking the Kubernetes API version then setting the ingress API version. In my case I use K3S which has version like  `v1.31.2+k3s1` which does not work with this check and incorrectly set the ingress versions to `networking.k8s.io/v1beta1`. Since that ingress version was dropped in 1.19 which came out in 2020 I thought it would be simpler to just drop support for 1.19 and lower and hard set the v1 API version. I have tested this change on my cluster then was able to create an ingress as expected.

Fixes #88 and #58