### PR TITLE
changed helm docs --dry-run command to correct chart

### DIFF
--- a/deploy/helm/charts/portainer/README.md
+++ b/deploy/helm/charts/portainer/README.md
@@ -10,7 +10,7 @@ kubectl create namespace portainer
 Execute the following for testing the chart:
 
 ```bash
-helm install --dry-run --debug portainer -n portainer deploy/helm/portainer
+helm install --dry-run --debug portainer -n portainer portainer/portainer
 ```
 
 # Installing the Chart


### PR DESCRIPTION
just a small change to correct an error on following the helm-install docs

This pull request includes a change to the `deploy/helm/charts/portainer/README.md` file to correct the command for testing the Helm chart.

* [`deploy/helm/charts/portainer/README.md`](diffhunk://#diff-1785064baea0298d3cb9b4a4f11cec28e585dc215d3b2f384b21cc9f185b5017L13-R13): Updated the Helm install command to use the correct chart path `portainer/portainer` instead of `deploy/helm/portainer`.

hopefully this is helpful, let me lnow if you'd rather i made this as an issue than a PR