### PR TITLE
Support extraVolumeMounts for pod 

### DIFF
--- a/charts/portainer/templates/deployment.yaml
+++ b/charts/portainer/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           secret:
             secretName: {{ .Values.mtls.existingSecret }}
         {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.enterpriseEdition.enabled }}
@@ -85,6 +88,9 @@ spec:
             - name: mtlscerts
               mountPath: /certs/mtls
               readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             {{- if not .Values.tls.force }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -26,6 +26,19 @@ serviceAccount:
   annotations: {}
   name: portainer-sa-clusteradmin
 
+
+# -- List of extra mounts to add (normally used with extraVolumes)
+extraVolumeMounts: []
+# - mountPath: /etc/ssl/certs/ca-certificates.crt
+#   name: host-ca-certificates
+#   readOnly: true
+
+# -- List of extra volumes to add
+extraVolumes: []
+# - hostPath:
+#     path: /etc/ssl/certs/ca-certificates.crt
+#   name: host-ca-certificates
+
 # This flag provides the ability to enable or disable RBAC-related resources during the deployment of the Portainer application
 # If you are using Portainer to manage the K8s cluster it is deployed to, this flag must be set to true 
 localMgmt: true


### PR DESCRIPTION
Linked issue https://github.com/orgs/portainer/discussions/9931#discussioncomment-10556329

This uses extraVolumeMounts to mount host CA to the container for trust internal root CA

```yaml 
# -- List of extra mounts to add (normally used with extraVolumes)
extraVolumeMounts:
- mountPath: /etc/ssl/certs/ca-certificates.crt
  name: host-ca-certificates
  readOnly: true

# -- List of extra volumes to add
extraVolumes:
- hostPath:
    path: /etc/ssl/certs/ca-certificates.crt
  name: host-ca-certificates
```
