### PR TITLE
feat: add multi-ingress support documentation

### DIFF
--- a/charts/portainer/Chart.yaml
+++ b/charts/portainer/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.0.66
+version: 1.0.67
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: ce-latest-ee-2.27.6

--- a/charts/portainer/README.md
+++ b/charts/portainer/README.md
@@ -91,3 +91,55 @@ The following table lists the configurable parameters of the Portainer chart and
 | `persistence.storageClass` | StorageClass to apply to PVC used for persistence | `default` |
 | `persistence.accessMode` | AccessMode for persistence | `ReadWriteOnce` |
 | `persistence.selector` | Selector for persistence | `nil` |
+
+## Ingress Configuration (Single or Multiple Ingress Resources)
+
+You can define your ingress configuration using the `ingress` key in your `values.yaml` file. This key supports both a single object (legacy) and an array (for multiple ingress resources):
+
+### Single Ingress (legacy)
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: "nginx"
+  annotations: {}
+  hosts:
+    - host: portainer.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          port: 9000
+  tls: []
+```
+
+### Multiple Ingresses
+```yaml
+ingress:
+  - name: portainer-http
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":8000}]'
+      alb.ingress.kubernetes.io/backend-protocol: HTTP
+    hosts:
+      - host: portainer.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+            port: 8000
+  - name: portainer-https
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/certificate-arn: <YOUR_CERT_ARN>
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":9443}]'
+      alb.ingress.kubernetes.io/backend-protocol: HTTPS
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    hosts:
+      - host: portainer.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+            port: 9443
+```
+
+If `ingress` is an array, each entry will result in a separate Kubernetes Ingress resource. If it is a map/object, only one Ingress will be created (legacy behavior).

--- a/charts/portainer/templates/ingress.yaml
+++ b/charts/portainer/templates/ingress.yaml
@@ -1,60 +1,113 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "portainer.fullname" . -}}
-{{- $tlsforced := .Values.tls.force -}}
-{{- $apiVersion := include "ingress.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "portainer.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-{{- with .Values.ingress.ingressClassName }}
-  ingressClassName: {{ . }}
-{{- end }}
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
-  rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ .path | default "/" }}
-            {{- if eq $apiVersion "networking.k8s.io/v1" }}
-            pathType: Prefix
-            {{- end }}
-            backend:
-            {{- if eq $apiVersion "networking.k8s.io/v1" }}
-              service:
-                name: {{ $fullName }}
-                port:
-                {{- if $tlsforced }}
-                  number: {{ .port | default 9443 }}
-                {{- else }}
-                  number: {{ .port | default 9000 }}
-                {{- end }}
-            {{- else }}
-              serviceName: {{ $fullName }}
-              {{- if $tlsforced }}
-              servicePort: {{ .port | default 9443 }}
-              {{- else }}
-              servicePort: {{ .port | default 9000 }}
-              {{- end }}
-            {{- end }}
+{{- if kindIs "array" .Values.ingress }}
+  {{- range $i, $ing := .Values.ingress }}
+    {{- if $ing.enabled }}
+      {{- $apiVersion := include "ingress.apiVersion" $ }}
+      apiVersion: {{ $apiVersion }}
+      kind: Ingress
+      metadata:
+        name: {{ include "portainer.fullname" $ }}-{{ $ing.name }}
+        namespace: {{ $.Release.Namespace }}
+        labels:
+          {{- include "portainer.labels" $ | nindent 10 }}
+        {{- with $ing.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
+      spec:
+        {{- with $ing.ingressClassName }}
+        ingressClassName: {{ . }}
+        {{- end }}
+        {{- if $ing.tls }}
+        tls:
+        {{- range $ing.tls }}
+          - hosts:
+            {{- range .hosts }}
+              - {{ . | quote }}
+            {{- end }}
+            secretName: {{ .secretName }}
+        {{- end }}
+        {{- end }}
+        rules:
+        {{- range $ing.hosts }}
+          - host: {{ .host | quote }}
+            http:
+              paths:
+              {{- range .paths }}
+                - path: {{ .path | default "/" }}
+                  {{- if eq $apiVersion "networking.k8s.io/v1" }}
+                  pathType: {{ .pathType | default "Prefix" }}
+                  {{- end }}
+                  backend:
+                  {{- if eq $apiVersion "networking.k8s.io/v1" }}
+                    service:
+                      name: {{ include "portainer.fullname" $ }}
+                      port:
+                        number: {{ .port | default 9000 }}
+                  {{- else }}
+                    serviceName: {{ include "portainer.fullname" $ }}
+                    servicePort: {{ .port | default 9000 }}
+                  {{- end }}
+              {{- end }}
+        {{- end }}
+    {{- end }}
   {{- end }}
+{{- else if and (kindIs "map" .Values.ingress) .Values.ingress.enabled }}
+  {{- $fullName := include "portainer.fullname" . -}}
+  {{- $tlsforced := .Values.tls.force -}}
+  {{- $apiVersion := include "ingress.apiVersion" . -}}
+  apiVersion: {{ $apiVersion }}
+  kind: Ingress
+  metadata:
+    name: {{ $fullName }}
+    namespace: {{ .Release.Namespace }}
+    labels:
+      {{- include "portainer.labels" . | nindent 4 }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  spec:
+  {{- with .Values.ingress.ingressClassName }}
+    ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+    tls:
+    {{- range .Values.ingress.tls }}
+      - hosts:
+        {{- range .hosts }}
+          - {{ . | quote }}
+        {{- end }}
+        secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+    rules:
+    {{- range .Values.ingress.hosts }}
+      - host: {{ .host | quote }}
+        http:
+          paths:
+          {{- range .paths }}
+            - path: {{ .path | default "/" }}
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              pathType: Prefix
+              {{- end }}
+              backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+                service:
+                  name: {{ $fullName }}
+                  port:
+                  {{- if $tlsforced }}
+                    number: {{ .port | default 9443 }}
+                  {{- else }}
+                    number: {{ .port | default 9000 }}
+                  {{- end }}
+              {{- else }}
+                serviceName: {{ $fullName }}
+                {{- if $tlsforced }}
+                servicePort: {{ .port | default 9443 }}
+                {{- else }}
+                servicePort: {{ .port | default 9000 }}
+                {{- end }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/portainer/values.yaml
+++ b/charts/portainer/values.yaml
@@ -58,6 +58,40 @@ mtls:
 feature:
   flags: []
 
+# Multi-ingress support:
+# You can define a single ingress object (legacy) or an array of ingress objects for multiple resources.
+# If ingress is an array, multiple Ingress resources will be created. If it is an object, only one will be created.
+# Example:
+# ingress:
+#   - name: portainer-http
+#     enabled: true
+#     annotations:
+#       kubernetes.io/ingress.class: alb
+#       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":8000}]'
+#       alb.ingress.kubernetes.io/backend-protocol: HTTP
+#     hosts:
+#       - host: portainer.example.com
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             port: 8000
+#   - name: portainer-https
+#     enabled: true
+#     annotations:
+#       kubernetes.io/ingress.class: alb
+#       alb.ingress.kubernetes.io/certificate-arn: <YOUR_CERT_ARN>
+#       alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":9443}]'
+#       alb.ingress.kubernetes.io/backend-protocol: HTTPS
+#       alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+#     hosts:
+#       - host: portainer.example.com
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             port: 9443
+#
+# If ingress is a map/object, the legacy single-ingress behavior is used.
+#
 ingress:
   enabled: false
   ingressClassName: ""


### PR DESCRIPTION
Resolves [portainer/k8s#173](https://github.com/portainer/k8s/issues/173)

**Summary**
- The Helm chart now supports defining multiple Kubernetes Ingress resources using the existing `ingress` key.
- `ingress` can be either a single object (legacy behavior) or an array (for multiple Ingress resources).
- The chart template logic and documentation have been updated accordingly.
**Details**
- If `ingress` is an array, each entry results in a separate Ingress resource (e.g., for HTTP and HTTPS, or multiple hosts).
- If `ingress` is a map/object, the chart behaves as before, creating a single Ingress resource.
- All documentation and examples in [README.md](https://didactic-palm-tree-p7pq95gjgv73776w.github.dev/) and [values.yaml](https://didactic-palm-tree-p7pq95gjgv73776w.github.dev/) have been updated to reflect this change.
- Chart version bumped to `1.0.67`.
**Why?**
This change allows users to manage multiple Ingress resources (e.g., for different ports, hosts, or controllers) in a single Helm release, improving flexibility and maintainability.